### PR TITLE
Remove redundant field from abstract shrewd model; fix #3

### DIFF
--- a/aso_models/models.py
+++ b/aso_models/models.py
@@ -35,9 +35,6 @@ class AbstractShrewdModel(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
-    activated_at = models.DateTimeField(
-        default=timezone.now, blank=True, null=True
-    )
     deleted_at = models.DateTimeField(blank=True, null=True)
 
     # model managers
@@ -77,13 +74,11 @@ class AbstractShrewdModel(models.Model):
 
     def _send_to_bin(self):
         self.deleted_at = timezone.now()
-        self.activated_at = None
         self.save()
         return 1, {}
 
     def _bring_back_from_bin(self):
         self.deleted_at = None
-        self.activated_at = timezone.now()
         self.save()
         return 1, {}
 

--- a/aso_models/querysets.py
+++ b/aso_models/querysets.py
@@ -14,14 +14,14 @@ class ShrewdQuerySet(models.QuerySet):
         super().__init__(*args, **kwargs)
         # ensure it only ever fetches objects which are not in the recycle bin
         self.query.add_q(
-            Q(deleted_at__isnull=True, activated_at__isnull=False)
+            Q(deleted_at__isnull=True)
         )
 
     def delete(self):
         '''
         Send the fetched objects into the recycle bin.
         '''
-        return self.update(deleted_at=timezone.now(), activated_at=None), {}
+        return self.update(deleted_at=timezone.now()), {}
 
     def restore(self):
         raise AssertionError(
@@ -61,4 +61,4 @@ class RecycleBinQuerySet(models.QuerySet):
         '''
         Send the fetched objects out of the recycle bin.
         '''
-        return self.update(deleted_at=None, activated_at=timezone.now())
+        return self.update(deleted_at=None)

--- a/aso_models/tests/test_models.py
+++ b/aso_models/tests/test_models.py
@@ -119,7 +119,6 @@ class ShrewdModelObjectTest(TransactionTestCase):
         self.viewable = mos[:3]
         self.recycled = mos[3:]
         for mo in self.recycled:
-            mo.activated_at = None
             mo.deleted_at = timezone.now()
             mo.save()
 

--- a/aso_models/tests/test_querysets.py
+++ b/aso_models/tests/test_querysets.py
@@ -52,9 +52,8 @@ class ShrewdQuerySetTest(TransactionTestCase):
         for mo in self.mos:
             mo.save()
         # populate the appropriate fields in the
-        # last four objects to simulate soft delete
+        # last four objects to simulate their respective soft deletion
         for mo in self.mos[-4:]:
-            mo.activated_at = None
             mo.deleted_at = timezone.now()
             mo.save()
 
@@ -65,11 +64,10 @@ class ShrewdQuerySetTest(TransactionTestCase):
     def test_shrewd_qs_fetch(self):
         '''
         Assert that shrewd queryset fetches only
-        active objects which are not currently soft-deleted.
+        objects which are not currently soft-deleted.
         '''
         self.assertEqual(self.shrewd_qs.count(), 6)
         for mo in self.shrewd_qs:
-            self.assertIsNotNone(mo.activated_at)
             self.assertIsNone(mo.deleted_at)
 
     def test_recycle_bin_fetch(self):


### PR DESCRIPTION
This PR fixes issue #3

It takes the redundant field, `activated_at`, out of the abstract shrewd model, and clean up all references to this field in the managers, querysets, and test cases.